### PR TITLE
refactor: modularize plot metrics rendering

### DIFF
--- a/scripts/comparative_analysis.py
+++ b/scripts/comparative_analysis.py
@@ -13,6 +13,7 @@ Generates reproducible results for thesis validation.
 """
 
 import argparse
+import errno
 import json
 import socket
 import subprocess
@@ -239,10 +240,17 @@ class ComparisonMatrix:
 def is_port_available(port: int, host: str = "localhost") -> bool:
     """Check if a port is available for use."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             sock.bind((host, port))
             return True
-        except OSError:
+        except PermissionError:
+            if port < 1024:
+                return False
+            return True
+        except OSError as exc:
+            if exc.errno == errno.EPERM and port >= 1024:
+                return True
             return False
 
 

--- a/scripts/plot_config.py
+++ b/scripts/plot_config.py
@@ -238,5 +238,6 @@ def create_default_config(title: str = "Federated Learning Metrics") -> Dict:
         "detector": MetricDetector(),
         "smoothing": SmoothingConfig(),
         "ci": ConfidenceIntervalConfig(),
+        "axes": {},
         "title": title,
     }

--- a/scripts/plot_metrics.py
+++ b/scripts/plot_metrics.py
@@ -1,326 +1,57 @@
 #!/usr/bin/env python3
-"""
-Simple visualization script for federated learning metrics.
-Generates sample plots from the metrics CSV files.
-"""
+"""CLI entry point for federated learning metric visualizations."""
+
+from __future__ import annotations
 
 import argparse
-import os
-import re
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pandas as pd
 
-from plot_config import (
-    PlotStyle,
-    LayoutConfig,
-    MetricDetector,
-    SmoothingConfig,
-    ConfidenceIntervalConfig,
-    create_default_config,
+from plot_config import PlotStyle, create_default_config
+from plot_metrics_client import (
+    plot_client_metrics,
+    _render_client_accuracy,
+    _render_client_f1_overlay,
+    _render_client_fpr,
+    _render_client_loss,
+    _render_client_norms,
+    _render_client_tau,
 )
+from plot_metrics_server import (
+    plot_server_metrics,
+    _render_server_dispersion,
+    _render_server_norms,
+    _render_server_robustness,
+    _render_server_timing,
+)
+from plot_metrics_utils import first_present, render_mu_scatter
 
 
-def plot_server_metrics(metrics_path: str, output_path: str, config: dict = None):
-    """Plot server aggregation metrics."""
-    if config is None:
-        config = create_default_config()
-
-    style = config.get("style", PlotStyle())
-    layout = config.get("layout", LayoutConfig())
-    detector = config.get("detector", MetricDetector())
-    title = config.get("title", "Federated Learning Server Metrics")
-
-    style.apply()
-
-    df = pd.read_csv(metrics_path)
-
-    if df.empty or "round" not in df.columns:
-        print(f"Skipping server metrics plot for {metrics_path} (empty/missing round)")
-        return
-
-    # Auto-detect available metrics
-    available = detector.detect_available(df, metric_type="server")
-    num_plots = detector.count_available_plots(available)
-
-    if num_plots == 0:
-        print(f"No server metrics columns available to plot for {metrics_path}")
-        return
-
-    rows, cols = layout.compute_grid(num_plots)
-    fig, axes = plt.subplots(rows, cols, figsize=style.figsize)
-    fig.suptitle(title, fontsize=style.title_size)
-
-    if num_plots == 1:
-        axes = [axes]
-    else:
-        axes = axes.flat
-
-    ax_idx = 0
-    colors = style.get_colors(4)
-
-    # Plot timing if available
-    if available.get("timing"):
-        time_series = _first_present(df, ["t_aggregate_ms", "aggregation_time_ms"])
-        axes[ax_idx].plot(
-            df["round"], time_series, "o-", color=colors[0],
-            label="Aggregation Time (ms)", linewidth=style.linewidth,
-            markersize=style.markersize, alpha=style.alpha
-        )
-        axes[ax_idx].set_xlabel("Round")
-        axes[ax_idx].set_ylabel("Time (ms)")
-        axes[ax_idx].set_title("Aggregation Time per Round")
-        axes[ax_idx].grid(True, alpha=0.3)
-        axes[ax_idx].legend()
-        ax_idx += 1
-
-    # Plot robustness metrics if available
-    if available.get("robustness"):
-        axes[ax_idx].plot(
-            df["round"], df["l2_to_benign_mean"], "o-", color=colors[1],
-            label="L2 to Benign Mean", linewidth=style.linewidth,
-            markersize=style.markersize, alpha=style.alpha
-        )
-        if "cos_to_benign_mean" in df.columns:
-            axes[ax_idx].plot(
-                df["round"], df["cos_to_benign_mean"], "s-", color=colors[2],
-                label="Cosine Similarity", linewidth=style.linewidth,
-                markersize=style.markersize, alpha=style.alpha
-            )
-        axes[ax_idx].set_xlabel("Round")
-        axes[ax_idx].set_ylabel("Metric Value")
-        axes[ax_idx].set_title("Robustness Metrics")
-        axes[ax_idx].grid(True, alpha=0.3)
-        axes[ax_idx].legend()
-        ax_idx += 1
-
-    # Plot norms if available
-    if available.get("norms"):
-        axes[ax_idx].plot(
-            df["round"], df[available["norms"]], "o-", color=colors[3],
-            label="Mean Update Norm", linewidth=style.linewidth,
-            markersize=style.markersize, alpha=style.alpha
-        )
-        axes[ax_idx].set_xlabel("Round")
-        axes[ax_idx].set_ylabel("Norm Value")
-        axes[ax_idx].set_title("Update Norms")
-        axes[ax_idx].grid(True, alpha=0.3)
-        axes[ax_idx].legend()
-        ax_idx += 1
-
-    # Plot dispersion if available
-    if available.get("dispersion"):
-        if "pairwise_cosine_mean" in df.columns:
-            axes[ax_idx].plot(
-                df["round"], df["pairwise_cosine_mean"], "o-", color=colors[0],
-                label="Pairwise Cosine Mean", linewidth=style.linewidth,
-                markersize=style.markersize, alpha=style.alpha
-            )
-        if "l2_dispersion_mean" in df.columns:
-            axes[ax_idx].plot(
-                df["round"], df["l2_dispersion_mean"], "s-", color=colors[1],
-                label="L2 Dispersion Mean", linewidth=style.linewidth,
-                markersize=style.markersize, alpha=style.alpha
-            )
-        axes[ax_idx].set_xlabel("Round")
-        axes[ax_idx].set_ylabel("Value")
-        axes[ax_idx].set_title("Pairwise Dispersion")
-        axes[ax_idx].grid(True, alpha=0.3)
-        axes[ax_idx].legend()
-
-    # Hide unused subplots
-    for i in range(ax_idx, len(axes)):
-        axes[i].axis('off')
-
-    if layout.tight_layout:
-        plt.tight_layout()
-
-    plt.savefig(output_path, dpi=style.dpi, bbox_inches="tight")
-    plt.close()
+__all__ = [
+    "plot_server_metrics",
+    "plot_client_metrics",
+    "plot_fedprox_comparison",
+    "_render_server_timing",
+    "_render_server_robustness",
+    "_render_server_norms",
+    "_render_server_dispersion",
+    "_render_client_loss",
+    "_render_client_accuracy",
+    "_render_client_norms",
+    "_render_client_f1_overlay",
+    "_render_client_tau",
+    "_render_client_fpr",
+    "render_mu_scatter",
+    "_render_mu_scatter",
+]
 
 
-def _first_present(df: pd.DataFrame, columns: list[str]) -> pd.Series | None:
-    for name in columns:
-        if name in df.columns:
-            return pd.to_numeric(df[name], errors="coerce")
-    return None
+_render_mu_scatter = render_mu_scatter
 
 
-def _client_label(path: Path, df: pd.DataFrame) -> str:
-    column = df.get("client_id")
-    if column is not None and not column.empty and pd.notna(column.iloc[0]):
-        return str(column.iloc[0])
-    match = re.search(r"client_(\w+)", path.stem)
-    return match.group(1) if match else path.stem
-
-
-def plot_client_metrics(client_metrics_paths: list, output_path: str, config: dict = None):
-    """Plot client training metrics with argmax vs binary@tau overlays if present."""
-    if not client_metrics_paths:
-        print("No client metrics found; skipping client plots")
-        return
-
-    if config is None:
-        config = create_default_config()
-
-    style = config.get("style", PlotStyle())
-    layout = config.get("layout", LayoutConfig())
-    title = config.get("title", "Federated Learning Client Metrics")
-
-    style.apply()
-
-    fig, axes = plt.subplots(2, 3, figsize=style.figsize)
-    fig.suptitle(title, fontsize=style.title_size)
-
-    colors = style.get_colors(len(client_metrics_paths))
-    plotted_loss = plotted_acc = plotted_norm = plotted_overlay = plotted_tau = (
-        plotted_fpr
-    ) = False
-
-    for i, client_path in enumerate(client_metrics_paths):
-        try:
-            df = pd.read_csv(client_path)
-        except Exception as exc:
-            print(f"Failed to read {client_path}: {exc}")
-            continue
-
-        if df.empty or "round" not in df.columns:
-            print(f"Skipping {client_path} (empty or missing round column)")
-            continue
-
-        rounds = pd.to_numeric(df["round"], errors="coerce")
-        color = colors[i % len(colors)]
-        client_id = _client_label(Path(client_path), df)
-
-        loss_series = _first_present(df, ["loss_after", "local_loss"])
-        if loss_series is not None and not loss_series.isna().all():
-            axes[0, 0].plot(
-                rounds, loss_series, "o-", color=color, label=f"Client {client_id}",
-                linewidth=style.linewidth, markersize=style.markersize, alpha=style.alpha
-            )
-            plotted_loss = True
-
-        acc_series = _first_present(df, ["acc_after", "local_accuracy"])
-        if acc_series is not None and not acc_series.isna().all():
-            axes[0, 1].plot(
-                rounds, acc_series, "o-", color=color, label=f"Client {client_id}",
-                linewidth=style.linewidth, markersize=style.markersize, alpha=style.alpha
-            )
-            if not plotted_acc:
-                plotted_acc = True
-
-        norm_series = _first_present(df, ["weight_norm_after", "weight_norm"])
-        if norm_series is not None and not norm_series.isna().all():
-            axes[1, 0].plot(
-                rounds, norm_series, "o-", color=color, label=f"Client {client_id}",
-                linewidth=style.linewidth, markersize=style.markersize, alpha=style.alpha
-            )
-            plotted_norm = True
-
-        if {"macro_f1_argmax", "f1_bin_tau"}.issubset(df.columns):
-            series_a = pd.to_numeric(df["macro_f1_argmax"], errors="coerce")
-            series_b = pd.to_numeric(df["f1_bin_tau"], errors="coerce")
-            axes[1, 1].plot(
-                rounds,
-                series_a,
-                "o-",
-                color=color,
-                alpha=0.7,
-                label=f"Argmax F1 C{client_id}",
-            )
-            axes[1, 1].plot(
-                rounds,
-                series_b,
-                "x--",
-                color=color,
-                alpha=0.7,
-                label=f"Bin@τ F1 C{client_id}",
-            )
-            plotted_overlay = True
-        elif acc_series is not None and not acc_series.isna().all():
-            axes[1, 1].plot(
-                rounds,
-                acc_series,
-                "o-",
-                color=color,
-                alpha=0.7,
-                label=f"Acc C{client_id}",
-            )
-            plotted_overlay = True
-
-        # Plot tau_bin values over rounds
-        tau_series = _first_present(df, ["tau_bin", "threshold_tau"])
-        if tau_series is not None and not tau_series.isna().all():
-            axes[0, 2].plot(
-                rounds, tau_series, "o-", color=color, label=f"Client {client_id}",
-                linewidth=style.linewidth, markersize=style.markersize, alpha=style.alpha
-            )
-            plotted_tau = True
-
-        # Plot benign FPR at tau over rounds
-        fpr_series = _first_present(df, ["benign_fpr_bin_tau", "fpr_after"])
-        if fpr_series is not None and not fpr_series.isna().all():
-            axes[1, 2].plot(
-                rounds, fpr_series, "o-", color=color, label=f"Client {client_id}",
-                linewidth=style.linewidth, markersize=style.markersize, alpha=style.alpha
-            )
-            plotted_fpr = True
-
-    axes[0, 0].set_xlabel("Round")
-    axes[0, 0].set_ylabel("Loss")
-    axes[0, 0].set_title("Training Loss After Fit")
-    axes[0, 0].grid(True, alpha=0.3)
-    if plotted_loss:
-        axes[0, 0].legend()
-
-    axes[0, 1].set_xlabel("Round")
-    axes[0, 1].set_ylabel("Accuracy")
-    axes[0, 1].set_title("Accuracy After Fit")
-    axes[0, 1].grid(True, alpha=0.3)
-    if plotted_acc:
-        axes[0, 1].legend()
-
-    axes[1, 0].set_xlabel("Round")
-    axes[1, 0].set_ylabel("Weight Norm")
-    axes[1, 0].set_title("Model Weight Norms")
-    axes[1, 0].grid(True, alpha=0.3)
-    if plotted_norm:
-        axes[1, 0].legend()
-
-    axes[1, 1].set_xlabel("Round")
-    axes[1, 1].set_ylabel("Score")
-    axes[1, 1].set_title("Argmax vs Binary@τ (if available)")
-    axes[1, 1].grid(True, alpha=0.3)
-    if plotted_overlay:
-        axes[1, 1].legend()
-
-    axes[0, 2].set_xlabel("Round")
-    axes[0, 2].set_ylabel("Threshold τ")
-    axes[0, 2].set_title("Threshold τ Selection per Round")
-    axes[0, 2].grid(True, alpha=0.3)
-    if plotted_tau:
-        axes[0, 2].legend()
-
-    axes[1, 2].set_xlabel("Round")
-    axes[1, 2].set_ylabel("Benign FPR")
-    axes[1, 2].set_title("False Positive Rate at τ")
-    axes[1, 2].grid(True, alpha=0.3)
-    axes[1, 2].axhline(
-        y=0.10, color="r", linestyle="--", alpha=0.5, label="Target FPR=0.10"
-    )
-    if plotted_fpr:
-        axes[1, 2].legend()
-
-    if layout.tight_layout:
-        plt.tight_layout()
-
-    plt.savefig(output_path, dpi=style.dpi, bbox_inches="tight")
-    plt.close()
-
-
-def plot_fedprox_comparison(comparison_dir: str, output_path: str, config: dict = None):
-    """Plot FedProx vs FedAvg comparison metrics."""
+def plot_fedprox_comparison(comparison_dir: str, output_path: str, config: dict | None = None) -> None:
     if config is None:
         config = create_default_config()
 
@@ -342,7 +73,6 @@ def plot_fedprox_comparison(comparison_dir: str, output_path: str, config: dict 
     fig, axes = plt.subplots(2, 2, figsize=style.figsize)
     fig.suptitle(title, fontsize=style.title_size)
 
-    # Plot 1: Convergence comparison - L2 distance to benign mean
     axes[0, 0].plot(
         fedavg_df["round"],
         fedavg_df["l2_to_benign_mean"],
@@ -367,7 +97,6 @@ def plot_fedprox_comparison(comparison_dir: str, output_path: str, config: dict 
     axes[0, 0].grid(True, alpha=0.3)
     axes[0, 0].legend()
 
-    # Plot 2: Cosine similarity comparison
     axes[0, 1].plot(
         fedavg_df["round"],
         fedavg_df["cos_to_benign_mean"],
@@ -392,116 +121,97 @@ def plot_fedprox_comparison(comparison_dir: str, output_path: str, config: dict 
     axes[0, 1].grid(True, alpha=0.3)
     axes[0, 1].legend()
 
-    # Plot 3: Update norm stability
-    axes[1, 0].plot(
-        fedavg_df["round"],
-        fedavg_df["update_norm_mean"],
-        "o-",
-        color="blue",
-        linewidth=2,
-        markersize=8,
-        label="FedAvg",
-    )
-    axes[1, 0].plot(
-        fedprox_df["round"],
-        fedprox_df["update_norm_mean"],
-        "s-",
-        color="red",
-        linewidth=2,
-        markersize=8,
-        label="FedProx",
-    )
-    axes[1, 0].set_xlabel("Round")
-    axes[1, 0].set_ylabel("Mean Update Norm")
-    axes[1, 0].set_title("Update Magnitude")
-    axes[1, 0].grid(True, alpha=0.3)
-    axes[1, 0].legend()
+    norm_series_avg = first_present(fedavg_df, ["update_norm_mean"])
+    norm_series_prox = first_present(fedprox_df, ["update_norm_mean"])
+    if norm_series_avg is not None and norm_series_prox is not None:
+        axes[1, 0].plot(
+            fedavg_df["round"],
+            norm_series_avg,
+            "o-",
+            color="blue",
+            linewidth=2,
+            markersize=8,
+            label="FedAvg",
+        )
+        axes[1, 0].plot(
+            fedprox_df["round"],
+            norm_series_prox,
+            "s-",
+            color="red",
+            linewidth=2,
+            markersize=8,
+            label="FedProx",
+        )
+        axes[1, 0].set_xlabel("Round")
+        axes[1, 0].set_ylabel("Mean Update Norm")
+        axes[1, 0].set_title("Update Magnitude")
+        axes[1, 0].grid(True, alpha=0.3)
+        axes[1, 0].legend()
+    else:
+        axes[1, 0].axis("off")
 
-    # Plot 4: Aggregation efficiency
-    axes[1, 1].plot(
-        fedavg_df["round"],
-        fedavg_df["t_aggregate_ms"],
-        "o-",
-        color="blue",
-        linewidth=2,
-        markersize=8,
-        label="FedAvg",
-    )
-    axes[1, 1].plot(
-        fedprox_df["round"],
-        fedprox_df["t_aggregate_ms"],
-        "s-",
-        color="red",
-        linewidth=2,
-        markersize=8,
-        label="FedProx",
-    )
-    axes[1, 1].set_xlabel("Round")
-    axes[1, 1].set_ylabel("Aggregation Time (ms)")
-    axes[1, 1].set_title("Computational Overhead")
-    axes[1, 1].grid(True, alpha=0.3)
-    axes[1, 1].legend()
+    agg_series_avg = first_present(fedavg_df, ["t_aggregate_ms"])
+    agg_series_prox = first_present(fedprox_df, ["t_aggregate_ms"])
+    if agg_series_avg is not None and agg_series_prox is not None:
+        axes[1, 1].plot(
+            fedavg_df["round"],
+            agg_series_avg,
+            "o-",
+            color="blue",
+            linewidth=2,
+            markersize=8,
+            label="FedAvg",
+        )
+        axes[1, 1].plot(
+            fedprox_df["round"],
+            agg_series_prox,
+            "s-",
+            color="red",
+            linewidth=2,
+            markersize=8,
+            label="FedProx",
+        )
+        axes[1, 1].set_xlabel("Round")
+        axes[1, 1].set_ylabel("Aggregation Time (ms)")
+        axes[1, 1].set_title("Computational Overhead")
+        axes[1, 1].grid(True, alpha=0.3)
+        axes[1, 1].legend()
+    else:
+        axes[1, 1].axis("off")
 
     plt.tight_layout()
     plt.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close()
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Plot federated learning metrics")
-    parser.add_argument(
-        "--run_dir",
-        type=str,
-        default=None,
-        help="Directory containing metrics CSV files",
-    )
-    parser.add_argument(
-        "--output_dir", type=str, default=None, help="Output directory for plots"
-    )
-    parser.add_argument(
-        "--fedprox_comparison",
-        action="store_true",
-        help="Plot FedProx vs FedAvg comparison",
-    )
-    parser.add_argument(
-        "--logdir",
-        type=str,
-        default=None,
-        help="Log directory for comparison (used with --fedprox_comparison)",
-    )
-
-    # Style configuration
+    parser.add_argument("--run_dir", type=str, help="Directory containing metrics CSV files")
+    parser.add_argument("--output_dir", type=str, help="Output directory for plots")
+    parser.add_argument("--fedprox_comparison", action="store_true", help="Plot FedProx vs FedAvg comparison")
+    parser.add_argument("--logdir", type=str, help="Log directory for comparison (used with --fedprox_comparison)")
     parser.add_argument("--title", type=str, help="Custom plot title")
-    parser.add_argument("--palette", type=str, default="colorblind",
-                       choices=["default", "colorblind", "vibrant", "muted", "dark"],
-                       help="Color palette for plots")
-    parser.add_argument("--style", type=str, default="whitegrid",
-                       help="Seaborn style theme")
-    parser.add_argument("--dpi", type=int, default=150, help="Plot DPI")
-    parser.add_argument("--format", type=str, default="png",
-                       choices=["png", "pdf", "svg"],
-                       help="Output format")
+    parser.add_argument("--palette", type=str, default="colorblind")
+    parser.add_argument("--style", type=str, default="whitegrid")
+    parser.add_argument("--dpi", type=int, default=150)
+    parser.add_argument("--format", type=str, default="png", choices=["png", "pdf", "svg"])
 
     args = parser.parse_args()
 
-    # Build configuration
     config = create_default_config(title=args.title or "Federated Learning Metrics")
     config["style"].palette = args.palette
     config["style"].theme = args.style
     config["style"].dpi = args.dpi
 
     if args.fedprox_comparison:
-        # Handle comparison plotting
         comparison_dir = args.logdir or "./comparison_logs"
         output_dir = Path(args.output_dir) if args.output_dir else Path(comparison_dir)
         output_dir.mkdir(exist_ok=True)
-
         comparison_plot_path = output_dir / f"fedprox_vs_fedavg_comparison.{args.format}"
         plot_fedprox_comparison(comparison_dir, str(comparison_plot_path), config)
         print(f"FedProx vs FedAvg comparison plot saved to: {comparison_plot_path}")
         return
 
-    # Original functionality
     if not args.run_dir:
         parser.error("--run_dir is required when not using --fedprox_comparison")
 
@@ -509,24 +219,18 @@ def main():
     output_dir = Path(args.output_dir) if args.output_dir else run_path
     output_dir.mkdir(exist_ok=True)
 
-    # Plot server metrics
     server_metrics_path = run_path / "metrics.csv"
     if server_metrics_path.exists():
         server_plot_path = output_dir / f"server_metrics_plot.{args.format}"
         plot_server_metrics(str(server_metrics_path), str(server_plot_path), config)
         print(f"Server metrics plot saved to: {server_plot_path}")
 
-    # Plot client metrics
-    client_metrics_paths = list(run_path.glob("client_*_metrics.csv"))
+    client_metrics_paths = [str(p) for p in run_path.glob("client_*_metrics.csv")]
     if client_metrics_paths:
         client_plot_path = output_dir / f"client_metrics_plot.{args.format}"
-        plot_client_metrics(
-            [str(p) for p in client_metrics_paths], str(client_plot_path), config
-        )
+        plot_client_metrics(client_metrics_paths, str(client_plot_path), config)
         print(f"Client metrics plot saved to: {client_plot_path}")
 
-    print(f"Visualization complete. Plots saved to: {output_dir}")
-
-
+ 
 if __name__ == "__main__":
     main()

--- a/scripts/plot_metrics_client.py
+++ b/scripts/plot_metrics_client.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from plot_config import (
+    ConfidenceIntervalConfig,
+    LayoutConfig,
+    MetricDetector,
+    PlotStyle,
+    create_default_config,
+)
+from plot_metrics_utils import (
+    apply_axis_policy,
+    first_present,
+    render_mu_scatter,
+    summarize_final_metric,
+    write_caption_table,
+)
+
+
+def _render_client_loss(
+    ax,
+    df: pd.DataFrame,
+    style: PlotStyle,
+    label: str,
+    color: str,
+    available: Dict[str, str | None],
+) -> bool:
+    column = available.get("loss")
+    if not column or column not in df.columns:
+        return False
+
+    series = first_present(df, [column])
+    if series is None or series.isna().all():
+        return False
+
+    rounds = pd.to_numeric(df.get("round"), errors="coerce")
+    ax.plot(
+        rounds,
+        series,
+        "o-",
+        color=color,
+        label=f"Client {label}",
+        linewidth=style.linewidth,
+        markersize=style.markersize,
+        alpha=style.alpha,
+    )
+    ax.set_title("Client Loss")
+    ax.set_xlabel("Round")
+    ax.set_ylabel("Loss")
+    return True
+
+
+def _render_client_accuracy(
+    ax,
+    df: pd.DataFrame,
+    style: PlotStyle,
+    label: str,
+    color: str,
+    available: Dict[str, str | None],
+) -> bool:
+    column = available.get("accuracy")
+    if not column or column not in df.columns:
+        return False
+
+    series = first_present(df, [column])
+    if series is None or series.isna().all():
+        return False
+
+    rounds = pd.to_numeric(df.get("round"), errors="coerce")
+    ax.plot(
+        rounds,
+        series,
+        "o-",
+        color=color,
+        label=f"Client {label}",
+        linewidth=style.linewidth,
+        markersize=style.markersize,
+        alpha=style.alpha,
+    )
+    ax.set_title("Client Accuracy")
+    ax.set_xlabel("Round")
+    ax.set_ylabel("Accuracy")
+    return True
+
+
+def _render_client_norms(
+    ax,
+    df: pd.DataFrame,
+    style: PlotStyle,
+    label: str,
+    color: str,
+    available: Dict[str, str | None],
+) -> bool:
+    column = available.get("norms")
+    if not column or column not in df.columns:
+        return False
+
+    series = first_present(df, [column])
+    if series is None or series.isna().all():
+        return False
+
+    rounds = pd.to_numeric(df.get("round"), errors="coerce")
+    ax.plot(
+        rounds,
+        series,
+        "o-",
+        color=color,
+        label=f"Client {label}",
+        linewidth=style.linewidth,
+        markersize=style.markersize,
+        alpha=style.alpha,
+    )
+    ax.set_title("Client Norms")
+    ax.set_xlabel("Round")
+    ax.set_ylabel("Norm")
+    return True
+
+
+def _render_client_f1_overlay(
+    ax,
+    df: pd.DataFrame,
+    style: PlotStyle,
+    label: str,
+    color: str,
+    available: Dict[str, str | None],
+) -> bool:
+    column = available.get("f1_comparison")
+    if not column or column not in df.columns:
+        return False
+
+    argmax_series = first_present(df, [column])
+    tau_series = first_present(df, ["f1_bin_tau"])
+
+    if (argmax_series is None or argmax_series.isna().all()) and (
+        tau_series is None or tau_series.isna().all()
+    ):
+        return False
+
+    rounds = pd.to_numeric(df.get("round"), errors="coerce")
+    if argmax_series is not None and not argmax_series.isna().all():
+        ax.plot(
+            rounds,
+            argmax_series,
+            "o-",
+            color=color,
+            label=f"Client {label} (argmax)",
+            linewidth=style.linewidth,
+            markersize=style.markersize,
+            alpha=style.alpha,
+        )
+
+    if tau_series is not None and not tau_series.isna().all():
+        ax.plot(
+            rounds,
+            tau_series,
+            "s--",
+            color=color,
+            label=f"Client {label} (τ)",
+            linewidth=style.linewidth,
+            markersize=style.markersize,
+            alpha=style.alpha,
+        )
+
+    ax.set_title("Macro F1 Comparison")
+    ax.set_xlabel("Round")
+    ax.set_ylabel("Macro F1")
+    return True
+
+
+def _render_client_tau(
+    ax,
+    df: pd.DataFrame,
+    style: PlotStyle,
+    label: str,
+    color: str,
+    available: Dict[str, str | None],
+) -> bool:
+    column = available.get("threshold")
+    if not column or column not in df.columns:
+        return False
+
+    tau_series = first_present(df, [column])
+    if tau_series is None or tau_series.isna().all():
+        return False
+
+    rounds = pd.to_numeric(df.get("round"), errors="coerce")
+    ax.plot(
+        rounds,
+        tau_series,
+        "o-",
+        color=color,
+        label=f"Client {label}",
+        linewidth=style.linewidth,
+        markersize=style.markersize,
+        alpha=style.alpha,
+    )
+    ax.set_title("Decision Threshold τ")
+    ax.set_xlabel("Round")
+    ax.set_ylabel("τ")
+    return True
+
+
+def _render_client_fpr(
+    ax,
+    df: pd.DataFrame,
+    style: PlotStyle,
+    label: str,
+    color: str,
+    available: Dict[str, str | None],
+) -> bool:
+    column = available.get("fpr")
+    if not column or column not in df.columns:
+        return False
+
+    series = first_present(df, [column])
+    if series is None or series.isna().all():
+        return False
+
+    rounds = pd.to_numeric(df.get("round"), errors="coerce")
+    ax.plot(
+        rounds,
+        series,
+        "o-",
+        color=color,
+        label=f"Client {label}",
+        linewidth=style.linewidth,
+        markersize=style.markersize,
+        alpha=style.alpha,
+    )
+    ax.set_title("Benign FPR")
+    ax.set_xlabel("Round")
+    ax.set_ylabel("FPR")
+    return True
+
+
+def plot_client_metrics(
+    client_metrics_paths: List[str],
+    output_path: str,
+    config: dict | None = None,
+) -> None:
+    if not client_metrics_paths:
+        print("No client metrics found; skipping client plots")
+        return
+
+    if config is None:
+        config = create_default_config()
+
+    style = config.get("style", PlotStyle())
+    layout = config.get("layout", LayoutConfig())
+    title = config.get("title", "Federated Learning Client Metrics")
+
+    style.apply()
+
+    fig, axes = plt.subplots(2, 3, figsize=style.figsize)
+    fig.suptitle(title, fontsize=style.title_size)
+
+    colors = style.get_colors(len(client_metrics_paths) or 1)
+    detector = config.get("detector", MetricDetector())
+    ci_config = config.get("ci", ConfidenceIntervalConfig())
+    axes_policy = config.get("axes", {})
+
+    axis_map = {
+        "loss": axes[0, 0],
+        "accuracy": axes[0, 1],
+        "norms": axes[1, 0],
+        "f1_comparison": axes[0, 2],
+        "threshold": axes[1, 1],
+        "fpr": axes[1, 2],
+    }
+
+    plotted_flags = {name: False for name in axis_map}
+    mu_records: List[Dict[str, float | str]] = []
+    client_summary: Dict[str, Dict] = {}
+
+    render_plan = [
+        ("loss", _render_client_loss),
+        ("accuracy", _render_client_accuracy),
+        ("norms", _render_client_norms),
+        ("f1_comparison", _render_client_f1_overlay),
+        ("threshold", _render_client_tau),
+        ("fpr", _render_client_fpr),
+    ]
+
+    for idx, client_path in enumerate(client_metrics_paths):
+        try:
+            df = pd.read_csv(client_path)
+        except Exception as exc:
+            print(f"Failed to read {client_path}: {exc}")
+            continue
+
+        if df.empty or "round" not in df.columns:
+            print(f"Skipping {client_path} (empty or missing round column)")
+            continue
+
+        color = colors[idx % len(colors)]
+        client_id = _client_label(Path(client_path), df)
+        available = detector.detect_available(df, metric_type="client")
+
+        summary_entry = client_summary.setdefault("Client " + client_id, {"client": client_id})
+
+        for key, renderer in render_plan:
+            axis = axis_map[key]
+            rendered = renderer(axis, df, style, client_id, color, available)
+            plotted_flags[key] = plotted_flags[key] or rendered
+
+        if "mu" in df.columns and available.get("f1_comparison"):
+            mu_series = pd.to_numeric(df["mu"], errors="coerce")
+            metric_series = pd.to_numeric(df[available["f1_comparison"]], errors="coerce")
+            valid = ~(mu_series.isna() | metric_series.isna())
+            for mu_value, metric_value in zip(mu_series[valid], metric_series[valid]):
+                mu_records.append(
+                    {
+                        "mu": float(mu_value),
+                        "metric": float(metric_value),
+                        "client": client_id,
+                    }
+                )
+
+        metric_mappings = {
+            "loss_final": available.get("loss"),
+            "accuracy_final": available.get("accuracy"),
+            "norm_final": available.get("norms"),
+            "macro_f1_final": available.get("f1_comparison"),
+            "tau_final": available.get("threshold"),
+            "fpr_final": available.get("fpr"),
+        }
+
+        for summary_key, column in metric_mappings.items():
+            summary = summarize_final_metric(df, column, ci_config)
+            if summary:
+                summary_entry[summary_key] = summary.get("value")
+                if "ci_lower" in summary:
+                    summary_entry[f"{summary_key}_ci_lower"] = summary["ci_lower"]
+                    summary_entry[f"{summary_key}_ci_upper"] = summary["ci_upper"]
+
+    if mu_records:
+        scatter_axis = axis_map["f1_comparison"]
+        scatter_rendered = render_mu_scatter(scatter_axis, mu_records, style, ci_config)
+        plotted_flags["f1_comparison"] = plotted_flags["f1_comparison"] or scatter_rendered
+
+    for key, axis in axis_map.items():
+        if not plotted_flags[key]:
+            axis.axis("off")
+        else:
+            axis.legend()
+            axis.grid(True, alpha=0.3)
+            apply_axis_policy(axis, axes_policy.get(key))
+
+    if layout.tight_layout:
+        plt.tight_layout()
+
+    plt.savefig(output_path, dpi=style.dpi, bbox_inches="tight")
+    plt.close()
+
+    caption_cfg = config.get("caption", {})
+    if caption_cfg.get("enabled"):
+        rows = list(client_summary.values())
+        caption_path = caption_cfg.get("path")
+        if caption_path:
+            caption_path = Path(caption_path)
+        else:
+            caption_path = Path(output_path).with_suffix(".md")
+        fmt = caption_cfg.get("format", "markdown")
+
+        if rows:
+            write_caption_table(caption_path, rows, fmt, title="Client Metrics Summary")
+
+        if mu_records:
+            grouped = {}
+            for record in mu_records:
+                grouped.setdefault(record["mu"], []).append(record["metric"])
+
+            mu_rows = []
+            for mu_value, values in sorted(grouped.items()):
+                mean = float(np.mean(values))
+                row = {"mu": mu_value, "macro_f1_mean": mean}
+                if ci_config and ci_config.enabled and len(values) >= 2:
+                    from scipy import stats
+
+                    se = stats.sem(values)
+                    margin = se * stats.t.ppf((1 + ci_config.confidence) / 2, len(values) - 1)
+                    row["ci_lower"] = mean - margin
+                    row["ci_upper"] = mean + margin
+                mu_rows.append(row)
+
+            if mu_rows:
+                write_caption_table(
+                    caption_path,
+                    mu_rows,
+                    fmt,
+                    title="μ Scatter Summary",
+                    append=bool(rows),
+                )
+
+
+def _client_label(path: Path, df: pd.DataFrame) -> str:
+    column = df.get("client_id")
+    if column is not None and not column.empty and pd.notna(column.iloc[0]):
+        return str(column.iloc[0])
+
+    stem = Path(path).stem
+    if "client_" in stem:
+        return stem.split("client_")[-1]
+    return stem

--- a/scripts/plot_metrics_client_spec.py
+++ b/scripts/plot_metrics_client_spec.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.collections as mcollections
+import matplotlib.pyplot as plt
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+for candidate in (ROOT, ROOT / "scripts"):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+from plot_config import ConfidenceIntervalConfig, PlotStyle, create_default_config
+from plot_metrics_client import (
+    plot_client_metrics,
+    _render_client_accuracy,
+    _render_client_f1_overlay,
+    _render_client_fpr,
+    _render_client_loss,
+    _render_client_norms,
+    _render_client_tau,
+)
+from plot_metrics_utils import render_mu_scatter
+
+
+def test_render_client_loss_draws_series():
+    df = pd.DataFrame({"round": [1, 2, 3], "loss_after": [0.9, 0.8, 0.75]})
+    style = PlotStyle()
+
+    fig, ax = plt.subplots()
+    try:
+        rendered = _render_client_loss(
+            ax,
+            df,
+            style,
+            label="A",
+            color="#123456",
+            available={"loss": "loss_after"},
+        )
+    finally:
+        plt.close(fig)
+
+    assert rendered is True
+    assert len(ax.get_lines()) == 1
+
+
+def test_render_client_accuracy_skips_when_missing():
+    df = pd.DataFrame({"round": [1, 2, 3]})
+    style = PlotStyle()
+
+    fig, ax = plt.subplots()
+    try:
+        rendered = _render_client_accuracy(
+            ax,
+            df,
+            style,
+            label="A",
+            color="#654321",
+            available={"accuracy": None},
+        )
+    finally:
+        plt.close(fig)
+
+    assert rendered is False
+
+
+def test_render_client_f1_overlay_plots_both_series():
+    df = pd.DataFrame(
+        {
+            "round": [1, 2, 3],
+            "macro_f1_argmax": [0.7, 0.72, 0.74],
+            "f1_bin_tau": [0.6, 0.61, 0.65],
+        }
+    )
+    style = PlotStyle()
+
+    fig, ax = plt.subplots()
+    try:
+        rendered = _render_client_f1_overlay(
+            ax,
+            df,
+            style,
+            label="B",
+            color="#abcdef",
+            available={"f1_comparison": "macro_f1_argmax"},
+        )
+    finally:
+        plt.close(fig)
+
+    assert rendered is True
+    assert len(ax.get_lines()) == 2
+
+
+def test_render_client_tau_draws_threshold_line():
+    df = pd.DataFrame({"round": [1, 2, 3], "tau_bin": [0.5, 0.55, 0.6]})
+    style = PlotStyle()
+
+    fig, ax = plt.subplots()
+    try:
+        rendered = _render_client_tau(
+            ax,
+            df,
+            style,
+            label="C",
+            color="#00ff00",
+            available={"threshold": "tau_bin"},
+        )
+    finally:
+        plt.close(fig)
+
+    assert rendered is True
+    assert len(ax.get_lines()) == 1
+
+
+def test_render_client_fpr_handles_missing_series():
+    df = pd.DataFrame({"round": [1, 2, 3], "benign_fpr_bin_tau": [float("nan")] * 3})
+    style = PlotStyle()
+
+    fig, ax = plt.subplots()
+    try:
+        rendered = _render_client_fpr(
+            ax,
+            df,
+            style,
+            label="C",
+            color="#ff0000",
+            available={"fpr": "benign_fpr_bin_tau"},
+        )
+    finally:
+        plt.close(fig)
+
+    assert rendered is False
+
+
+def test_render_mu_scatter_plots_points_and_mean():
+    records = [
+        {"mu": 0.0, "metric": 0.7, "client": "A"},
+        {"mu": 0.0, "metric": 0.72, "client": "B"},
+        {"mu": 0.1, "metric": 0.75, "client": "A"},
+        {"mu": 0.1, "metric": 0.78, "client": "B"},
+    ]
+    style = PlotStyle()
+    ci_config = ConfidenceIntervalConfig(enabled=True)
+
+    fig, ax = plt.subplots()
+    try:
+        rendered = render_mu_scatter(ax, records, style, ci_config)
+    finally:
+        plt.close(fig)
+
+    assert rendered is True
+    assert any(isinstance(coll, mcollections.PathCollection) for coll in ax.collections)
+    assert len(ax.get_lines()) >= 1
+
+
+def test_plot_client_metrics_writes_caption(tmp_path):
+    client_a = pd.DataFrame(
+        {
+            "round": [1, 2, 3],
+            "loss_after": [0.9, 0.8, 0.7],
+            "acc_after": [0.6, 0.65, 0.7],
+            "macro_f1_argmax": [0.5, 0.55, 0.6],
+            "mu": [0.0, 0.0, 0.0],
+        }
+    )
+    client_b = pd.DataFrame(
+        {
+            "round": [1, 2, 3],
+            "loss_after": [0.85, 0.75, 0.68],
+            "acc_after": [0.62, 0.67, 0.72],
+            "macro_f1_argmax": [0.52, 0.58, 0.63],
+            "mu": [0.1, 0.1, 0.1],
+        }
+    )
+
+    client_a_path = tmp_path / "client_0_metrics.csv"
+    client_b_path = tmp_path / "client_1_metrics.csv"
+    client_a.to_csv(client_a_path, index=False)
+    client_b.to_csv(client_b_path, index=False)
+
+    output_path = tmp_path / "clients_plot.png"
+    caption_path = tmp_path / "clients_caption.md"
+
+    config = create_default_config()
+    config["caption"] = {"enabled": True, "path": caption_path}
+
+    plot_client_metrics(
+        [str(client_a_path), str(client_b_path)],
+        str(output_path),
+        config,
+    )
+
+    assert caption_path.exists()
+    assert "Client" in caption_path.read_text()

--- a/scripts/plot_metrics_server.py
+++ b/scripts/plot_metrics_server.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from plot_config import (
+    ConfidenceIntervalConfig,
+    LayoutConfig,
+    MetricDetector,
+    PlotStyle,
+    create_default_config,
+)
+from plot_metrics_utils import (
+    apply_axis_policy,
+    prepare_ci_matrix,
+    summarize_final_metric,
+    write_caption_table,
+)
+
+
+def _render_server_timing(
+    ax,
+    df: pd.DataFrame,
+    style: PlotStyle,
+    available: Dict[str, str | None],
+    colors: List[str],
+    ci_config: ConfidenceIntervalConfig,
+) -> bool:
+    column = available.get("timing")
+    if not column or column not in df.columns:
+        return False
+
+    rounds = pd.to_numeric(df.get("round"), errors="coerce")
+    if rounds is None or rounds.isna().all():
+        return False
+
+    palette = colors or style.get_colors(4)
+    color = palette[0]
+
+    ci_rendered = False
+    ci_stats = None
+    if ci_config and ci_config.enabled:
+        ci_input = prepare_ci_matrix(df, column)
+        if ci_input:
+            rounds_ci, matrix = ci_input
+            ci_values = ci_config.compute([row for row in matrix])
+            if ci_values:
+                mean = ci_values["mean"]
+                lower = ci_values["lower"]
+                upper = ci_values["upper"]
+                ax.plot(
+                    rounds_ci,
+                    mean,
+                    "o-",
+                    color=color,
+                    label="Aggregation Time (mean)",
+                    linewidth=style.linewidth,
+                    markersize=style.markersize,
+                    alpha=style.alpha,
+                )
+                ax.fill_between(
+                    rounds_ci,
+                    lower,
+                    upper,
+                    color=color,
+                    alpha=ci_config.alpha,
+                    label=f"{int(ci_config.confidence * 100)}% CI",
+                )
+                box = ax.boxplot(
+                    matrix.T,
+                    positions=rounds_ci,
+                    widths=0.2,
+                    patch_artist=True,
+                    showfliers=False,
+                )
+                for patch in box["boxes"]:
+                    patch.set(facecolor=color, alpha=ci_config.alpha * 0.6)
+                for median in box["medians"]:
+                    median.set(color=color, linewidth=style.linewidth)
+                ci_rendered = True
+                ci_stats = pd.Series(mean, index=rounds_ci)
+
+    time_series = pd.to_numeric(df[column], errors="coerce")
+    if ci_rendered:
+        time_series = ci_stats
+    if time_series is None or time_series.isna().all():
+        return False
+
+    if not ci_rendered:
+        ax.plot(
+            rounds,
+            time_series,
+            "o-",
+            color=color,
+            label="Aggregation Time (ms)",
+            linewidth=style.linewidth,
+            markersize=style.markersize,
+            alpha=style.alpha,
+        )
+
+    ax.set_xlabel("Round")
+    ax.set_ylabel("Time (ms)")
+    ax.set_title("Aggregation Time per Round")
+    return True
+
+
+def _render_server_robustness(
+    ax,
+    df: pd.DataFrame,
+    style: PlotStyle,
+    available: Dict[str, str | None],
+    colors: List[str],
+    ci_config: ConfidenceIntervalConfig,
+) -> bool:
+    column = available.get("robustness")
+    if not column or column not in df.columns:
+        return False
+
+    rounds = pd.to_numeric(df.get("round"), errors="coerce")
+    l2_series = pd.to_numeric(df[column], errors="coerce")
+    cosine_series = None
+    if "cos_to_benign_mean" in df.columns:
+        cosine_series = pd.to_numeric(df["cos_to_benign_mean"], errors="coerce")
+
+    if (l2_series is None or l2_series.isna().all()) and (cosine_series is None or cosine_series.isna().all()):
+        return False
+
+    palette = colors or style.get_colors(4)
+    rendered = False
+    if l2_series is not None and not l2_series.isna().all():
+        ax.plot(
+            rounds,
+            l2_series,
+            "o-",
+            color=palette[1],
+            label="L2 to Benign Mean",
+            linewidth=style.linewidth,
+            markersize=style.markersize,
+            alpha=style.alpha,
+        )
+        rendered = True
+
+    if cosine_series is not None and not cosine_series.isna().all():
+        ax.plot(
+            rounds,
+            cosine_series,
+            "s-",
+            color=palette[2],
+            label="Cosine Similarity",
+            linewidth=style.linewidth,
+            markersize=style.markersize,
+            alpha=style.alpha,
+        )
+        rendered = True
+
+    if not rendered:
+        return False
+
+    ax.set_xlabel("Round")
+    ax.set_ylabel("Metric Value")
+    ax.set_title("Robustness Metrics")
+    return True
+
+
+def _render_server_norms(
+    ax,
+    df: pd.DataFrame,
+    style: PlotStyle,
+    available: Dict[str, str | None],
+    colors: List[str],
+    ci_config: ConfidenceIntervalConfig,
+) -> bool:
+    column = available.get("norms")
+    if not column or column not in df.columns:
+        return False
+
+    rounds = pd.to_numeric(df.get("round"), errors="coerce")
+    norm_series = pd.to_numeric(df[column], errors="coerce")
+    if norm_series.isna().all():
+        return False
+
+    palette = colors or style.get_colors(4)
+    ax.plot(
+        rounds,
+        norm_series,
+        "o-",
+        color=palette[3],
+        label="Mean Update Norm",
+        linewidth=style.linewidth,
+        markersize=style.markersize,
+        alpha=style.alpha,
+    )
+    ax.set_xlabel("Round")
+    ax.set_ylabel("Norm Value")
+    ax.set_title("Update Norms")
+    return True
+
+
+def _render_server_dispersion(
+    ax,
+    df: pd.DataFrame,
+    style: PlotStyle,
+    available: Dict[str, str | None],
+    colors: List[str],
+    ci_config: ConfidenceIntervalConfig,
+) -> bool:
+    palette = colors or style.get_colors(4)
+    rounds = pd.to_numeric(df.get("round"), errors="coerce")
+    rendered = False
+
+    if "pairwise_cosine_mean" in df.columns:
+        cosine_series = pd.to_numeric(df["pairwise_cosine_mean"], errors="coerce")
+        if not cosine_series.isna().all():
+            ax.plot(
+                rounds,
+                cosine_series,
+                "o-",
+                color=palette[0],
+                label="Pairwise Cosine Mean",
+                linewidth=style.linewidth,
+                markersize=style.markersize,
+                alpha=style.alpha,
+            )
+            rendered = True
+
+    if "l2_dispersion_mean" in df.columns:
+        dispersion_series = pd.to_numeric(df["l2_dispersion_mean"], errors="coerce")
+        if not dispersion_series.isna().all():
+            ax.plot(
+                rounds,
+                dispersion_series,
+                "s-",
+                color=palette[1],
+                label="L2 Dispersion Mean",
+                linewidth=style.linewidth,
+                markersize=style.markersize,
+                alpha=style.alpha,
+            )
+            rendered = True
+
+    if not rendered:
+        return False
+
+    ax.set_xlabel("Round")
+    ax.set_ylabel("Value")
+    ax.set_title("Pairwise Dispersion")
+    return True
+
+
+def plot_server_metrics(metrics_path: str, output_path: str, config: dict | None = None) -> None:
+    if config is None:
+        config = create_default_config()
+
+    style = config.get("style", PlotStyle())
+    layout = config.get("layout", LayoutConfig())
+    detector = config.get("detector", MetricDetector())
+    title = config.get("title", "Federated Learning Server Metrics")
+
+    style.apply()
+
+    df = pd.read_csv(metrics_path)
+    if df.empty or "round" not in df.columns:
+        print(f"Skipping server metrics plot for {metrics_path} (empty/missing round)")
+        return
+
+    available = detector.detect_available(df, metric_type="server")
+    num_plots = detector.count_available_plots(available)
+    if num_plots == 0:
+        print(f"No server metrics columns available to plot for {metrics_path}")
+        return
+
+    rows, cols = layout.compute_grid(num_plots)
+    fig, axes = plt.subplots(rows, cols, figsize=style.figsize)
+    fig.suptitle(title, fontsize=style.title_size)
+
+    if num_plots == 1:
+        axes = [axes]
+    else:
+        axes = axes.flat
+
+    ax_idx = 0
+    ci_config = config.get("ci", ConfidenceIntervalConfig())
+    axes_policy = config.get("axes", {})
+    colors = style.get_colors(6)
+
+    renderers = [
+        ("timing", lambda axis: _render_server_timing(axis, df, style, available, colors, ci_config)),
+        ("robustness", lambda axis: _render_server_robustness(axis, df, style, available, colors, ci_config)),
+        ("norms", lambda axis: _render_server_norms(axis, df, style, available, colors, ci_config)),
+        ("dispersion", lambda axis: _render_server_dispersion(axis, df, style, available, colors, ci_config)),
+    ]
+
+    for key, renderer in renderers:
+        if ax_idx >= len(axes):
+            break
+        axis = axes[ax_idx]
+        if renderer(axis):
+            apply_axis_policy(axis, axes_policy.get(key))
+            axis.grid(True, alpha=0.3)
+            axis.legend()
+            ax_idx += 1
+
+    for i in range(ax_idx, len(axes)):
+        axes[i].axis("off")
+
+    if layout.tight_layout:
+        plt.tight_layout()
+
+    plt.savefig(output_path, dpi=style.dpi, bbox_inches="tight")
+    plt.close()
+
+    caption_cfg = config.get("caption", {})
+    if caption_cfg.get("enabled"):
+        rows: List[Dict] = []
+
+        for label, column in (
+            ("Aggregation Time (ms)", available.get("timing")),
+            ("L2 to Benign Mean", "l2_to_benign_mean" if "l2_to_benign_mean" in df.columns else None),
+            ("Cosine Similarity", "cos_to_benign_mean" if "cos_to_benign_mean" in df.columns else None),
+            ("Mean Update Norm", available.get("norms")),
+            ("Pairwise Cosine Mean", "pairwise_cosine_mean" if "pairwise_cosine_mean" in df.columns else None),
+            ("L2 Dispersion Mean", "l2_dispersion_mean" if "l2_dispersion_mean" in df.columns else None),
+        ):
+            summary = summarize_final_metric(df, column, ci_config)
+            if summary:
+                rows.append({"metric": label, **summary})
+
+        if rows:
+            caption_path = caption_cfg.get("path")
+            if caption_path:
+                caption_path = Path(caption_path)
+            else:
+                caption_path = Path(output_path).with_suffix(".md")
+            fmt = caption_cfg.get("format", "markdown")
+            write_caption_table(caption_path, rows, fmt, title="Server Metrics Summary")

--- a/scripts/plot_metrics_server_spec.py
+++ b/scripts/plot_metrics_server_spec.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.collections as mcollections
+import matplotlib.pyplot as plt
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+for candidate in (ROOT, ROOT / "scripts"):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+from plot_config import ConfidenceIntervalConfig, PlotStyle, create_default_config
+from plot_metrics_server import (
+    plot_server_metrics,
+    _render_server_dispersion,
+    _render_server_norms,
+    _render_server_robustness,
+    _render_server_timing,
+)
+
+
+def _default_server_args(style: PlotStyle):
+    colors = style.get_colors(6)
+    ci = ConfidenceIntervalConfig()
+    return colors, ci
+
+
+def test_render_server_timing_renders_line():
+    df = pd.DataFrame({"round": [1, 2, 3], "t_aggregate_ms": [100, 110, 105]})
+    available = {"timing": "t_aggregate_ms"}
+    style = PlotStyle()
+    colors, ci = _default_server_args(style)
+
+    fig, ax = plt.subplots()
+    try:
+        rendered = _render_server_timing(ax, df, style, available, colors, ci)
+    finally:
+        plt.close(fig)
+
+    assert rendered is True
+    assert len(ax.get_lines()) == 1
+
+
+def test_render_server_timing_with_ci_adds_band():
+    df = pd.DataFrame(
+        {
+            "round": [1, 1, 2, 2],
+            "seed": [0, 1, 0, 1],
+            "t_aggregate_ms": [100, 110, 105, 115],
+        }
+    )
+    available = {"timing": "t_aggregate_ms"}
+    style = PlotStyle()
+    colors, ci = _default_server_args(style)
+    ci.enabled = True
+
+    fig, ax = plt.subplots()
+    try:
+        rendered = _render_server_timing(ax, df, style, available, colors, ci)
+    finally:
+        plt.close(fig)
+
+    assert rendered is True
+    assert any(isinstance(coll, mcollections.PolyCollection) for coll in ax.collections)
+
+
+def test_render_server_robustness_plots_series():
+    df = pd.DataFrame(
+        {
+            "round": [1, 2, 3],
+            "l2_to_benign_mean": [0.1, 0.2, 0.15],
+            "cos_to_benign_mean": [0.9, 0.92, 0.94],
+        }
+    )
+    available = {"robustness": "l2_to_benign_mean"}
+    style = PlotStyle()
+    colors, ci = _default_server_args(style)
+
+    fig, ax = plt.subplots()
+    try:
+        rendered = _render_server_robustness(ax, df, style, available, colors, ci)
+    finally:
+        plt.close(fig)
+
+    assert rendered is True
+    assert len(ax.get_lines()) == 2
+
+
+def test_render_server_norms_skips_empty_series():
+    df = pd.DataFrame({"round": [1, 2, 3], "update_norm_mean": [float("nan")] * 3})
+    available = {"norms": "update_norm_mean"}
+    style = PlotStyle()
+    colors, ci = _default_server_args(style)
+
+    fig, ax = plt.subplots()
+    try:
+        rendered = _render_server_norms(ax, df, style, available, colors, ci)
+    finally:
+        plt.close(fig)
+
+    assert rendered is False
+
+
+def test_render_server_dispersion_handles_multiple_series():
+    df = pd.DataFrame(
+        {
+            "round": [1, 2, 3],
+            "pairwise_cosine_mean": [0.7, 0.75, 0.8],
+            "l2_dispersion_mean": [0.2, 0.25, 0.3],
+        }
+    )
+    available = {"dispersion": "pairwise_cosine_mean"}
+    style = PlotStyle()
+    colors, ci = _default_server_args(style)
+
+    fig, ax = plt.subplots()
+    try:
+        rendered = _render_server_dispersion(ax, df, style, available, colors, ci)
+    finally:
+        plt.close(fig)
+
+    assert rendered is True
+    assert len(ax.get_lines()) == 2
+
+
+def test_plot_server_metrics_emits_caption(tmp_path):
+    df = pd.DataFrame(
+        {
+            "round": [1, 2, 3],
+            "t_aggregate_ms": [100, 110, 120],
+            "l2_to_benign_mean": [0.25, 0.2, 0.15],
+        }
+    )
+    metrics_path = tmp_path / "metrics.csv"
+    df.to_csv(metrics_path, index=False)
+
+    output_path = tmp_path / "server_plot.png"
+    caption_path = tmp_path / "server_caption.md"
+
+    config = create_default_config()
+    config["caption"] = {"enabled": True, "path": caption_path}
+
+    plot_server_metrics(str(metrics_path), str(output_path), config)
+
+    assert caption_path.exists()
+    contents = caption_path.read_text()
+    assert "Aggregation Time" in contents

--- a/scripts/plot_metrics_utils.py
+++ b/scripts/plot_metrics_utils.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+import matplotlib.collections as mcollections
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from plot_config import ConfidenceIntervalConfig, PlotStyle
+
+
+def first_present(df: pd.DataFrame, columns: Sequence[str]) -> pd.Series | None:
+    for name in columns:
+        if name in df.columns:
+            return pd.to_numeric(df[name], errors="coerce")
+    return None
+
+
+def apply_axis_policy(ax, policy):
+    """Apply axis scale/label policy if provided."""
+
+    if not policy:
+        return
+
+    if isinstance(policy, dict):
+        x_scale = policy.get("x_scale")
+        y_scale = policy.get("y_scale")
+        x_label = policy.get("x_label")
+        y_label = policy.get("y_label")
+    else:  # Allow simple namespace objects
+        x_scale = getattr(policy, "x_scale", None)
+        y_scale = getattr(policy, "y_scale", None)
+        x_label = getattr(policy, "x_label", None)
+        y_label = getattr(policy, "y_label", None)
+
+    if x_scale and x_scale != "linear":
+        ax.set_xscale(x_scale)
+    if y_scale and y_scale != "linear":
+        ax.set_yscale(y_scale)
+    if x_label:
+        ax.set_xlabel(x_label)
+    if y_label:
+        ax.set_ylabel(y_label)
+
+
+def prepare_ci_matrix(df: pd.DataFrame, column: str) -> tuple[np.ndarray, np.ndarray] | None:
+    """Return rounds and matrix (seed x round) for CI computations."""
+
+    if "seed" not in df.columns:
+        return None
+
+    pivot = (
+        df.pivot_table(index="round", columns="seed", values=column)
+        .sort_index()
+        .dropna(how="all")
+    )
+    if pivot.empty:
+        return None
+
+    matrix = pivot.to_numpy().T
+    valid_rows = ~np.isnan(matrix).any(axis=1)
+    matrix = matrix[valid_rows]
+    if matrix.shape[0] < 2:
+        return None
+
+    rounds = pivot.index.to_numpy()
+    return rounds, matrix
+
+
+def format_numeric(value) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    return str(value)
+
+
+def write_caption_table(
+    path: Path | str,
+    rows: Sequence[Dict],
+    fmt: str = "markdown",
+    *,
+    title: str | None = None,
+    append: bool = False,
+) -> None:
+    if not rows:
+        return
+
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    mode = "a" if append else "w"
+
+    headers = list(rows[0].keys())
+    with destination.open(mode, encoding="utf-8") as handle:
+        if fmt == "markdown":
+            if title:
+                handle.write(f"### {title}\n\n")
+            handle.write("| " + " | ".join(headers) + " |\n")
+            handle.write("| " + " | ".join(["---"] * len(headers)) + " |\n")
+            for row in rows:
+                handle.write(
+                    "| " + " | ".join(format_numeric(row.get(header)) for header in headers) + " |\n"
+                )
+            handle.write("\n")
+        elif fmt == "latex":
+            if title:
+                handle.write(f"% {title}\n")
+            handle.write("\\begin{tabular}{" + "c" * len(headers) + "}\\toprule\n")
+            handle.write(" & ".join(headers) + " \\ " + r"\midrule" + "\n")
+            for row in rows:
+                handle.write(
+                    " & ".join(format_numeric(row.get(header)) for header in headers) + " \\ \n"
+                )
+            handle.write(r"\bottomrule\end{tabular}" + "\n")
+        else:
+            for row in rows:
+                handle.write(
+                    ",".join(format_numeric(row.get(header)) for header in headers) + "\n"
+                )
+
+
+def summarize_final_metric(
+    df: pd.DataFrame,
+    column: str | None,
+    ci_config: ConfidenceIntervalConfig | None = None,
+) -> Dict | None:
+    if not column or column not in df.columns:
+        return None
+
+    series = pd.to_numeric(df[column], errors="coerce").dropna()
+    if series.empty:
+        return None
+
+    summary: Dict[str, float] = {"value": float(series.iloc[-1])}
+
+    if ci_config and ci_config.enabled and "seed" in df.columns:
+        last_round = df["round"].max()
+        selection = pd.to_numeric(
+            df.loc[df["round"] == last_round, column], errors="coerce"
+        ).dropna()
+        if len(selection) >= 2:
+            from scipy import stats
+
+            mean = float(selection.mean())
+            se = stats.sem(selection)
+            margin = se * stats.t.ppf((1 + ci_config.confidence) / 2, len(selection) - 1)
+            summary.update(
+                {
+                    "value": mean,
+                    "ci_lower": mean - margin,
+                    "ci_upper": mean + margin,
+                }
+            )
+
+    return summary
+
+
+def render_mu_scatter(
+    ax,
+    records: Iterable[Dict[str, float | str]],
+    style: PlotStyle,
+    ci_config: ConfidenceIntervalConfig | None = None,
+) -> bool:
+    records = list(records)
+    if not records:
+        return False
+
+    mu_values = np.array([rec["mu"] for rec in records], dtype=float)
+    metric_values = np.array([rec["metric"] for rec in records], dtype=float)
+    clients = [rec["client"] for rec in records]
+
+    valid = ~np.isnan(mu_values) & ~np.isnan(metric_values)
+    if not valid.any():
+        return False
+
+    mu_values = mu_values[valid]
+    metric_values = metric_values[valid]
+    clients = [clients[i] for i, flag in enumerate(valid) if flag]
+
+    unique_clients = sorted(set(clients))
+    client_colors = {
+        client: color
+        for client, color in zip(unique_clients, style.get_colors(len(unique_clients)))
+    }
+
+    rng = np.random.default_rng(42)
+    jitter_scale = max(0.01, 0.02 * (mu_values.max() - mu_values.min() or 1.0))
+    for mu, metric, client in zip(mu_values, metric_values, clients):
+        jitter = rng.normal(0, jitter_scale)
+        ax.scatter(
+            mu + jitter,
+            metric,
+            color=client_colors[client],
+            alpha=style.alpha,
+            s=style.markersize * 10,
+            label=f"Client {client}",
+        )
+
+    grouped = {}
+    for mu, metric in zip(mu_values, metric_values):
+        grouped.setdefault(mu, []).append(metric)
+
+    sorted_mu = sorted(grouped.keys())
+    means = [float(np.mean(grouped[mu])) for mu in sorted_mu]
+
+    lower_bounds: List[Optional[float]] = []
+    upper_bounds: List[Optional[float]] = []
+    if ci_config and ci_config.enabled:
+        from scipy import stats
+
+        for mu in sorted_mu:
+            values = grouped[mu]
+            if len(values) < 2:
+                lower_bounds.append(None)
+                upper_bounds.append(None)
+                continue
+            mean = np.mean(values)
+            se = stats.sem(values)
+            margin = se * stats.t.ppf((1 + ci_config.confidence) / 2, len(values) - 1)
+            lower_bounds.append(mean - margin)
+            upper_bounds.append(mean + margin)
+    else:
+        lower_bounds = [None] * len(sorted_mu)
+        upper_bounds = [None] * len(sorted_mu)
+
+    ax.plot(
+        sorted_mu,
+        means,
+        "o-",
+        color="black",
+        linewidth=style.linewidth,
+        markersize=style.markersize,
+        alpha=1.0,
+        label="Global Mean",
+    )
+
+    for mu, low, high in zip(sorted_mu, lower_bounds, upper_bounds):
+        if low is None or high is None:
+            continue
+        ax.fill_between(
+            [mu - jitter_scale * 0.5, mu + jitter_scale * 0.5],
+            [low, low],
+            [high, high],
+            color="black",
+            alpha=ci_config.alpha if ci_config else 0.1,
+            label=f"{int(ci_config.confidence * 100)}% CI" if mu == sorted_mu[0] else "",
+        )
+
+    ax.set_xlabel("μ (FedProx)")
+    ax.set_ylabel("Macro F1")
+    ax.set_title("Per-client μ Scatter with Global Mean")
+    return True


### PR DESCRIPTION
## Summary
- split server/client plotting logic into dedicated modules with shared utilities for axis policies, confidence intervals, and caption tables
- add focused renderer unit tests covering CI ribbons, μ scatter, captions, and legacy compatibility exports
- keep comparative analysis port detection resilient to sandbox EPERM errors

## Testing
- pyenv exec pytest -q