### PR TITLE
fix(ci): update CI workflows to use full UNSW dataset

### DIFF
--- a/scripts/comparative_analysis.py
+++ b/scripts/comparative_analysis.py
@@ -47,7 +47,7 @@ class ExperimentConfig:
     seed: int
     fedprox_mu: float = 0.0
     dataset: str = "unsw"
-    data_path: str = "data/unsw/unsw_nb15_sample.csv"
+    data_path: str = "data/unsw/UNSW_NB15_training-set.csv"
 
     def to_preset_name(self) -> str:
         """Generate unique preset name for this configuration."""


### PR DESCRIPTION
## Summary

Updates CI workflows to use the full UNSW-NB15 dataset instead of the sampled version.

## Problem

Issue #28 was closed when PR #85 merged, but CI workflows were still using the sampled dataset:
- **Current**: `data/unsw/unsw_nb15_sample.csv` (1.1MB, 8.2k samples)  
- **Fixed**: `data/unsw/UNSW_NB15_training-set.csv` (15MB, 82k samples)

## Changes

- Updated `data_path` in `scripts/comparative_analysis.py` line 50
- CI workflows will now use complete dataset for comprehensive evaluation
- Ensures consistency with manual full dataset experiments

## Impact

- CI workflows will take longer but provide more comprehensive results
- Nightly experiments will use full dataset as intended
- Completes the full dataset evaluation requirement from issue #28

## Testing

- [x] Data path updated correctly
- [x] Full dataset file exists and is accessible
- [x] No breaking changes to existing functionality

Fixes #28