### PR TITLE
feat(metrics): Add fairness metrics to summary.json (Issue #9)

### DIFF
--- a/scripts/summarize_metrics.py
+++ b/scripts/summarize_metrics.py
@@ -28,10 +28,10 @@ def compute_fairness_metrics(client_metrics_df: pd.DataFrame) -> Dict:
 
     Returns:
         Dictionary with fairness metrics:
-        - worst_client_macro_f1_argmax: Minimum F1 across clients (final round)
-        - best_client_macro_f1_argmax: Maximum F1 across clients (final round)
-        - cv_macro_f1_argmax: Coefficient of variation of F1 across clients
-        - fraction_clients_fpr_le_0_10: Fraction of clients with FPR <= 0.10
+        - worst_client_macro_f1_argmax: Minimum F1 across clients (highest round per client)
+        - best_client_macro_f1_argmax: Maximum F1 across clients (highest round per client)
+        - cv_macro_f1_argmax: Coefficient of variation of F1 across clients (highest round per client)
+        - fraction_clients_fpr_le_0_10: Fraction of clients with FPR <= 0.10 (highest round per client)
         - rare_class_f1_mean: Mean F1 for rare classes (not implemented yet)
         - rare_class_f1_min: Min F1 for rare classes (not implemented yet)
     """
@@ -41,7 +41,7 @@ def compute_fairness_metrics(client_metrics_df: pd.DataFrame) -> Dict:
     fairness = {}
 
     if "macro_f1_argmax" in client_metrics_df.columns and "client_id" in client_metrics_df.columns:
-        f1_by_client = client_metrics_df.groupby("client_id")["macro_f1_argmax"].last()
+        f1_by_client = client_metrics_df.sort_values("round").groupby("client_id")["macro_f1_argmax"].last()
 
         if not f1_by_client.empty:
             fairness["worst_client_macro_f1_argmax"] = float(f1_by_client.min())
@@ -52,7 +52,7 @@ def compute_fairness_metrics(client_metrics_df: pd.DataFrame) -> Dict:
             fairness["cv_macro_f1_argmax"] = float(std_f1 / mean_f1) if mean_f1 > 0 else 0.0
 
     if "benign_fpr_argmax" in client_metrics_df.columns and "client_id" in client_metrics_df.columns:
-        fpr_by_client = client_metrics_df.groupby("client_id")["benign_fpr_argmax"].last()
+        fpr_by_client = client_metrics_df.sort_values("round").groupby("client_id")["benign_fpr_argmax"].last()
 
         if not fpr_by_client.empty:
             low_fpr_count = (fpr_by_client <= 0.10).sum()

--- a/test_fairness_metrics.py
+++ b/test_fairness_metrics.py
@@ -179,3 +179,35 @@ def test_compute_fairness_metrics_zero_mean_f1():
     result = compute_fairness_metrics(df)
 
     assert result["cv_macro_f1_argmax"] == 0.0
+
+
+def test_compute_fairness_metrics_unsorted_rounds():
+    """Extract final round correctly even when data is unsorted."""
+    data = {
+        "client_id": [0, 0, 0, 1, 1, 1],
+        "round": [5, 1, 3, 3, 5, 1],
+        "macro_f1_argmax": [0.90, 0.70, 0.75, 0.80, 0.88, 0.65],
+    }
+    df = pd.DataFrame(data)
+
+    result = compute_fairness_metrics(df)
+
+    assert result["worst_client_macro_f1_argmax"] == pytest.approx(0.88, abs=0.001)
+    assert result["best_client_macro_f1_argmax"] == pytest.approx(0.90, abs=0.001)
+
+
+def test_compute_fairness_metrics_unsorted_rounds_with_fpr():
+    """Extract final round FPR correctly even when data is unsorted."""
+    data = {
+        "client_id": [0, 0, 0, 1, 1, 1, 2, 2, 2],
+        "round": [5, 1, 3, 3, 5, 1, 1, 5, 3],
+        "benign_fpr_argmax": [0.05, 0.15, 0.10, 0.12, 0.08, 0.20, 0.25, 0.09, 0.18],
+    }
+    df = pd.DataFrame(data)
+
+    result = compute_fairness_metrics(df)
+
+    low_fpr_count = 3
+    total_clients = 3
+    expected_fraction = low_fpr_count / total_clients
+    assert result["fraction_clients_fpr_le_0_10"] == pytest.approx(expected_fraction, abs=0.001)


### PR DESCRIPTION
Resolves #9

## Summary

Enhances summary.json with fairness and disparity metrics to identify client-level performance inequalities and enable CI quality gates for fairness thresholds.

## Changes

### New Function
- `compute_fairness_metrics()`: Computes client-level fairness indicators
  - Worst/best client F1 (final round)
  - Coefficient of variation across clients
  - Fraction of clients with acceptable FPR (<=0.10)

### Integration
- Extended `summarize_clients()` to include fairness metrics in summary.json
- Backward compatible (existing keys preserved)

### Testing
- Added `test_fairness_metrics.py` with 11 comprehensive tests
- Tests cover computation logic, edge cases, missing columns
- Validates worst/best, CV, FPR fraction calculations

## New Metrics in summary.json

```json
{
  "worst_client_macro_f1_argmax": 0.821,
  "best_client_macro_f1_argmax": 0.869,
  "cv_macro_f1_argmax": 0.028,
  "fraction_clients_fpr_le_0_10": 0.833
}
```

## Test Results

```
358 tests passing (100%)
11 new tests for Issue #9
Black formatted
Ruff clean
```

## Use Cases

### CI Quality Gates
Enable fairness validation in CI:
```python
if summary["cv_macro_f1_argmax"] > 0.20:
    raise ValueError("Fairness violation: CV too high")
```

### Thesis Analysis
- Cite worst/best client metrics in fairness sections
- Quantify performance disparities across federation
- Identify experiments requiring fairness interventions

### Monitoring
- Track fraction of clients with acceptable FPR
- Detect client subgroups underperforming
- Flag experiments with high variance

## Technical Notes

- Uses `groupby().last()` to extract final round per client
- Handles missing columns gracefully (returns empty dict)
- CV computed with population std (ddof=0) for consistency
- FPR threshold set at 0.10 (standard low-FPR target)

## Future Work

Deferred to future iterations:
- `rare_class_f1_mean`: Requires per-class F1 columns
- `rare_class_f1_min`: Requires class support information

## Dependencies

None - pure enhancement, no external blockers.